### PR TITLE
[Integration] PullApprove

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -1,0 +1,28 @@
+version: 2
+
+# Group settings to apply to all groups by default, optionally being overridden later
+group_defaults:
+  approve_by_comment:
+    enabled: true
+    approve_regex: '^(Approved|:\+1:)'
+    reject_regex: '^(Rejected|:-1:)'
+  reset_on_push:
+    enabled: true
+  reset_on_reopened:
+    enabled: true
+
+# Groups of reviewers and their respective settings
+groups:
+  core-team:
+    required: 4
+
+    users:
+      - dpanayotov
+      - KirilKabakchiev
+      - dzahariev
+      - NickyMateev
+      - dotchev
+      - georgifarashev
+      - pankrator
+
+    reject_value: -1


### PR DESCRIPTION
# Integration with [PullApprove][1]

<b> The *specification* repo should be added to Pull Approve [HERE][2] by a repo admin (@dzahariev) before merging. </b>

The proposed configuration constitutes that any pull request to the *specification* repo can only be merged if at least 4 people from the **core-team** group approve it. 

Check the *.pullapprove.yml* file for more configuration settings.

Reference Issue: [Improve review process #19][3]

[1]: https://about.pullapprove.com/
[2]: https://pullapprove.com/start/
[3]: https://github.com/Peripli/specification/issues/19