### PR TITLE
Visibilities and Labels

### DIFF
--- a/api.md
+++ b/api.md
@@ -16,14 +16,20 @@
     - [Retrieving All Service Brokers](#retrieving-all-service-brokers)
     - [Deleting a Service Broker](#deleting-a-service-broker)
     - [Updating a Service Broker](#updating-a-service-broker)
-  - [Visibilities](#visibilities)
+  - [Visibility Management](#visibility-management)
     - [Creating a Visibility](#creating-a-visibility)
     - [Retrieving a Visibility](#reitrieving-a-visibility)
     - [Retrieving All Visibilities](#retrieving-all-visibilities)
     - [Deleting a Visibility](#deleting-a-visibility)
     - [Updating a Visibility](#updating-a-visibility)
   - [Labels](#labels)
-    - [Label Changes](#label-changes)
+    - [Syntax](#syntax)
+    - [Label Management](#label-management)
+        - [Attaching Labels](#attaching-labels)
+        - [Detaching Labels](#detaching-labels)
+        - [Adding Label Values](#adding-label-values)
+        - [Removing Label values](#removing-label-values)
+    - [Label Change Object](#label-change-object)
   - [Information](#information)
   - [Service Management](#service-management)
   - [Credentials Object](#credentials-object)
@@ -702,7 +708,7 @@ The response body MUST be a valid JSON Object (`{}`).
 
 ## Visibility Management
 
-Visibilities in the Service Manager are used to manage which platform sees which service plan. In addition, labels can be attached to a visibility to further scope the access of the plan inside the platform (if applicable).
+Visibilities in the Service Manager are used to manage which platform sees which service plan. If applicable, labels MAY be attached to a visibility to further scope the access of the plan inside the platform.
 
 ## Creating a Visibility
 
@@ -997,7 +1003,282 @@ The response body MUST be a valid JSON Object (`{}`).
 
 ## Labels
 
-## Label Changes
+Specific resources in the Service Manager MAY be labeled in order to be organized into groups relevant to the users.  
+This specification does not limit which resources MUST be labeled. However, all resources that might benefit from having labels, are presented in ther extended form contaning labels.
+
+### Syntax
+
+Labels MUST consist of one or more keys, where each key MUST be mapped to a list of values.  
+
+This specification does not restrict the allowed character set, length of keys and values or reserved/mandatory keys per resource.
+
+##### Labels Object
+```json
+{
+    ...
+    "labels": {
+        "key1": ["value1", "value2"],
+        "key2": ["value3", "value4"]
+    }
+}
+```
+
+### Label Management
+
+### Attaching Labels
+
+Labels SHOULD be attached to a resource at creation time, or later by updating the respective resource. For example on how to attach a label to a resource post-creation, see [Updating Labels](#updating-labels).
+
+### Route
+`POST /v1/:resource_type`
+
+`:resource_type` MUST be a valid Service Manager resource type. 
+
+### Request Body
+```json
+{
+    ...
+    "labels": {
+        "label1": ["value1"]
+    }
+}
+```
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| labels* | [labels object](#labels-object) | MUST be a valid labels object |
+
+\* Fields with an asterisk are REQUIRED.
+
+### Response
+
+Each `resource type` decides on the returned response statuses.  
+Below are the statuses that are recommended when attaching a label at creation time.
+
+| Status Code | Description |
+| ----------- | ----------- |
+| 201 Created | MUST be returned if the labels were created as a result of this request. The expected response body is below. |
+| 400 Bad Request | MUST be returned if the request is malformed, missing mandatory data or the labels have invalid syntax. The description field MAY be used to return a user-facing error message, providing details about which part of the request is malformed or what data is missing as described in [Errors](#errors).|
+
+#### Body
+
+The response body MUST be a valid JSON Object (`{}`).  
+The labels MUST be returned as part of the response.
+
+```json
+{
+    ...
+    "labels": {
+        "label1": ["value1"]
+    }
+}
+```
+
+| Response Field | Type | Description |
+| -------------- | ---- | ----------- |
+| labels*    | [Labels](#labels) object | Labels for this resource. |
+
+\* Fields with an asterisk are REQUIRED.
+
+### Detaching Labels
+
+Labels SHOULD be detached only by updating a resource.
+
+### Route
+`PATCH /v1/:resource_type/:resource_id`
+
+`:resource_type` MUST be a valid Service Manager resource type.  
+`:resource_id` MUST be the ID of a previously created resource of this resource type.
+
+### Request Body
+```json
+{
+    ...
+    "labels": [
+        {
+            "op": "remove",
+            "key": "label2"
+        }
+    ]
+}
+```
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| labels* | array of [Label Changes](#label-change-object) | MUST be a valid array of label changes |
+
+\* Fields with an asterisk are REQUIRED.
+
+### Response
+
+Each `resource type` decides on the returned response statuses.  
+Below are the statuses that are recommended when detaching a label.
+
+| Status Code | Description |
+| ----------- | ----------- |
+| 200 OK | MUST be returned if the labels were detached as a result of this request. The expected response body is below. |
+| 400 Bad Request | MUST be returned if the request is malformed, missing mandatory data or the label detachment is invalid. An invalid label detachment is one where either the label key has invalid syntax, or a label with such key was not previously attached to the resource. The description field MAY be used to return a user-facing error message, providing details about which part of the request is malformed or what data is missing as described in [Errors](#errors).|
+
+
+#### Body
+
+The response body MUST be a valid JSON Object (`{}`).  
+The calculated labels MUST be returned as part of the response.
+
+```json
+{
+    ...
+    "labels": {
+        "label1": ["value1"]
+    }
+}
+```
+
+| Response Field | Type | Description |
+| -------------- | ---- | ----------- |
+| labels*    | [Labels](#labels) object | Labels for this resource. |
+
+\* Fields with an asterisk are REQUIRED.
+
+### Adding Label Values
+
+Label values SHOULD be added only by updating the resource that the label is attached to.
+
+### Route
+`PATCH /v1/:resource_type/:resource_id`
+
+`:resource_type` MUST be a valid Service Manager resource type.  
+`:resource_id` MUST be the ID of a previously created resource of this resource type.
+
+### Request Body
+```json
+{
+    ...
+    "labels": [
+        {
+            "op": "add_values",
+            "key": "label1",
+            "values": ["value2", "value3"]
+        }
+    ]
+}
+```
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| labels* | array of [Label Changes](#label-change-object) | MUST be a valid array of label changes |
+
+\* Fields with an asterisk are REQUIRED.
+
+### Response
+
+Each `resource type` decides on the returned response statuses.  
+Below are the statuses that are recommended when adding new values to a label.
+
+| Status Code | Description |
+| ----------- | ----------- |
+| 200 OK | MUST be returned if the values were added to the label with the specified key as a result of this request. If a label with such key is not attached to the resource, it SHOULD be created and attached to the resource. The expected response body is below. |
+| 400 Bad Request | MUST be returned if the request is malformed, missing mandatory data or the label change is invalid. An invalid add-values label change is one where either the label key and/or values have invalid syntax, or one or more of the values are already mapped to a label with this key. The description field MAY be used to return a user-facing error message, providing details about which part of the request is malformed or what data is missing as described in [Errors](#errors).|
+
+#### Body
+
+The response body MUST be a valid JSON Object (`{}`).  
+The calculated labels MUST be returned as part of the response.
+
+```json
+{
+    ...
+    "labels": {
+        "label1": ["value1", "value2", "value3"]
+    }
+}
+```
+
+| Response Field | Type | Description |
+| -------------- | ---- | ----------- |
+| labels*    | [Labels](#labels) object | Labels for this resource. |
+
+\* Fields with an asterisk are REQUIRED.
+
+### Removing Label Values
+
+Label values SHOULD be removed only by updating the resource that the label is attached to.
+
+### Route
+`PATCH /v1/:resource_type/:resource_id`
+
+`:resource_type` MUST be a valid Service Manager resource type.  
+`:resource_id` MUST be the ID of a previously created resource of this resource type.
+
+### Request Body
+```json
+{
+    ...
+    "labels": [
+        {
+            "op": "remove_values",
+            "key": "label1",
+            "values": ["value2"]
+        }
+    ]
+}
+```
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| labels* | array of [Label Changes](#label-change-object) | MUST be a valid array of label changes |
+
+\* Fields with an asterisk are REQUIRED.
+
+### Response
+
+Each `resource type` decides on the returned response statuses for this resource.  
+Below are the statuses that are recommended when remove values from a label.
+
+| Status Code | Description |
+| ----------- | ----------- |
+| 200 OK | MUST be returned if the values were remove from the label with the specified key as a result of this request. The expected response body is below. |
+| 400 Bad Request | MUST be returned if the request is malformed, missing mandatory data or the label change is invalid. An invalid remove-values label change is one where either the label key and/or values have invalid syntax, one or more of the values were not mapped to a label with this key, or a label with this key is not attached to the resource. The description field MAY be used to return a user-facing error message, providing details about which part of the request is malformed or what data is missing as described in [Errors](#errors).|
+
+#### Body
+
+The response body MUST be a valid JSON Object (`{}`).  
+The calculated labels MUST be returned as part of the response.
+
+```json
+{
+    ...
+    "labels": {
+        "label1": ["value1", "value2", "value3"]
+    }
+}
+```
+
+| Response Field | Type | Description |
+| -------------- | ---- | ----------- |
+| labels*    | [Labels](#labels) object | Labels for this resource. |
+
+\* Fields with an asterisk are REQUIRED.
+
+## Label Change Object
+
+Each change of a label MUST be performed by passing a label change object, which is a JSON-Patch-like object that allows for modification of existing labels and attaching new labels to resources.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| op* | [label change operation](#label-change-operation) | Operation for updating the label change |
+| key* | string | Key of the label to be changed |
+| values* | array of strings | Values to be changed |
+
+\* Field MAY be required depending on the [label change operation](#label-change-operation).
+
+### Label Change Operation
+
+This specification does not limit the operations, but these are the minimum set of operations that MUST be supported.
+
+| Operation | Description |
+| --------- | ----------- |
+| add | Adds a new label with the specified key and values. All fields are required. |
+| add_values | Appends new values to the label with the specified key. All fields are required. |
+| remove | Removes the label with the specified key. `values` field is optional. `op` and `key` fields are required. |
+| remove_values | Removes the values from the label with the specified key. All fields are required. |
+
 
 ## Information
 

--- a/api.md
+++ b/api.md
@@ -16,6 +16,14 @@
     - [Retrieving All Service Brokers](#retrieving-all-service-brokers)
     - [Deleting a Service Broker](#deleting-a-service-broker)
     - [Updating a Service Broker](#updating-a-service-broker)
+  - [Visibilities](#visibilities)
+    - [Creating a Visibility](#creating-a-visibility)
+    - [Retrieving a Visibility](#reitrieving-a-visibility)
+    - [Retrieving All Visibilities](#retrieving-all-visibilities)
+    - [Deleting a Visibility](#deleting-a-visibility)
+    - [Updating a Visibility](#updating-a-visibility)
+  - [Labels](#labels)
+    - [Label Changes](#label-changes)
   - [Information](#information)
   - [Service Management](#service-management)
   - [Credentials Object](#credentials-object)
@@ -691,6 +699,305 @@ The response body MUST be a valid JSON Object (`{}`).
 | metadata | object | Additional data associated with the service broker. This JSON object MAY have arbitrary content. |
 
 \* Fields with an asterisk are REQUIRED.
+
+## Visibility Management
+
+Visibilities in the Service Manager are used to manage which platform sees which service plan. In addition, labels can be attached to a visibility to further scope the access of the plan inside the platform (if applicable).
+
+## Creating a Visibility
+
+### Route
+`POST /v1/visibilities`
+
+#### Headers
+
+The following HTTP Headers are defined for this operation:
+
+| Header | Type | Description |
+| --- | --- | --- |
+| Authorization* | string | Provides a means for authentication and authorization |
+
+\* Headers with an asterisk are REQUIRED.
+
+### Request Body
+```json
+{
+    "platform_id": "038001bc-80bd-4d67-bf3a-956e4d545e3c",
+    "service_plan_id": "fe173a83-df28-4891-8d91-46334e04600d",
+    "labels": {
+        "label1": ["value1"]
+    }
+}
+```
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| platform_id | string | If present, MUST be the ID of an existing Platform. If missing, this means that the plan is visible to all platforms. |
+| service_plan_id* | string | MUST be the ID of an existing Service Plan. |
+| labels | labels object | MUST be a valid labels object |
+
+\* Fields with an asterisk are REQUIRED.
+
+### Response
+
+| Status Code | Description |
+| ----------- | ----------- |
+| 201 Created | MUST be returned if the visibility was created as a result of this request. The expected response body is below. |
+| 400 Bad Request | MUST be returned if the request is malformed, missing mandatory data or the visibility is invalid. An invalid visibility is one where either the platform_id or service_plan_id do not exist, or a visibility for this service_plan_id already exists, but with an empty platform_id. The description field MAY be used to return a user-facing error message, providing details about which part of the request is malformed or what data is missing as described in [Errors](#errors).|
+| 409 Conflict | MUST be returned if a visibility for this platform_id and service_plan_id already exists. The `description` field MAY be used to return a user-facing error message, as described in [Errors](#errors). |
+
+Responses with any other status code will be interpreted as a failure. The response can include a user-facing message in the `description` field. For details see [Errors](#errors).
+
+#### Body
+
+The response body MUST be a valid JSON Object (`{}`).
+
+```json
+{
+    "id": "36931aaf-62a7-4019-a708-0e9abf7e7a8f",
+    "platform_id": "038001bc-80bd-4d67-bf3a-956e4d545e3c",
+    "service_plan_id": "fe173a83-df28-4891-8d91-46334e04600d",
+    "labels": {
+        "label1": ["value1"]
+    }
+}
+```
+
+| Response Field | Type | Description |
+| -------------- | ---- | ----------- |
+| id*            | string | ID of the visibility. |
+| platform_id          | string | ID of the Platform for this visibility. |
+| service_plan_id*    | string | ID of the Service plan for this visibility. |
+| labels    | [Labels](#labels) object | Labels for this visibility. |
+
+\* Fields with an asterisk are REQUIRED.
+
+## Retrieving a Visibility
+
+### Request
+
+#### Route
+
+`GET /v1/visibilities/:visibility_id`
+
+`:visibility_id` MUST be the ID of a previously created visibility
+
+#### Headers
+
+The following HTTP Headers are defined for this operation:
+
+| Header | Type | Description |
+| --- | --- | --- |
+| Authorization* | string | Provides a means for authentication and authorization |
+
+\* Headers with an asterisk are REQUIRED.
+
+### Response
+
+| Status Code | Description |
+| ----------- | ----------- |
+| 200 OK | MUST be returned if the request execution was successful. The expected response body is below. |
+| 404 Not Found | MUST be returned if the requested visibility is missing. The `description` field MAY be used to return a user-facing error message, as described in [Errors](#errors). |
+
+Responses with any other status code will be interpreted as a failure. The response can include a user-facing message in the `description` field. For details see [Errors](#errors).
+
+#### Body
+
+The response body MUST be a valid JSON Object (`{}`).
+
+##### Visibility Object
+```json
+{
+    "id": "36931aaf-62a7-4019-a708-0e9abf7e7a8f",
+    "platform_id": "038001bc-80bd-4d67-bf3a-956e4d545e3c",
+    "service_plan_id": "fe173a83-df28-4891-8d91-46334e04600d",
+    "labels": {
+        "label1": ["value1"]
+    }
+}
+```
+
+| Response Field | Type | Description |
+| -------------- | ---- | ----------- |
+| id*            | string | ID of the visibility. |
+| platform_id      | string | ID of the Platform for this visibility. |
+| service_plan_id* | string | ID of the Service plan for this visibility. |
+| labels    | [Labels](#labels) object | Labels for this visibility. |
+
+\* Fields with an asterisk are REQUIRED.
+
+## Retrieving All Visibilities
+
+### Request
+
+#### Route
+
+`GET /v1/visibilities`
+
+#### Headers
+
+The following HTTP Headers are defined for this operation:
+
+| Header | Type | Description |
+| --- | --- | --- |
+| Authorization* | string | Provides a means for authentication and authorization |
+
+\* Headers with an asterisk are REQUIRED.
+
+### Response
+
+| Status Code | Description |
+| ----------- | ----------- |
+| 200 OK | MUST be returned if the request execution was successful. The expected response body is below. |
+
+Responses with any other status code will be interpreted as a failure. The response can include a user-facing message in the `description` field. For details see [Errors](#errors).
+
+#### Body
+
+The response body MUST be a valid JSON Object (`{}`).
+
+```json
+{
+    "visibilities": [
+        {
+            "id": "36931aaf-62a7-4019-a708-0e9abf7e7a8f",
+            "platform_id": "038001bc-80bd-4d67-bf3a-956e4d545e3c",
+            "service_plan_id": "fe173a83-df28-4891-8d91-46334e04600d",
+            "labels": {
+                "label1": ["value1"]
+            }
+        },
+        {
+            "id": "fbb0692a-76f3-42f6-b537-58b1be7ec618",
+            "platform_id": "e031d646-62a5-4a50-9d8e-23165172e9e1",
+            "service_plan_id": "acsded31-c303-123a-aab9-8crar19e1218",
+            "labels": {
+                "label2": ["value2"]
+            }
+        }
+    ]
+    
+}
+```
+
+| Response Field | Type | Description |
+| -------------- | ---- | ----------- |
+| visibilities*  | array of [visibilities](#visibility-object) | List of existing visibilities. |
+
+\* Fields with an asterisk are REQUIRED.
+
+## Deleting a Visibility
+
+### Request
+
+#### Route
+
+`DELETE /v1/visibilities/:visibility_id`
+
+`:visibility_id` MUST be the ID of a previously created visibility
+
+#### Headers
+
+The following HTTP Headers are defined for this operation:
+
+| Header | Type | Description |
+| --- | --- | --- |
+| Authorization* | string | Provides a means for authentication and authorization |
+
+\* Headers with an asterisk are REQUIRED.
+
+### Response
+
+| Status Code | Description |
+| ----------- | ----------- |
+| 200 OK | MUST be returned if the request execution was successful. The expected response body is below. |
+| 400 Bad Request | MUST be returned if the request is malformed or missing mandatory data. The `description` field MAY be used to return a user-facing error message, as described in [Errors](#errors).|
+| 404 Not Found | MUST be returned if the requested visibility is missing. The `description` field MAY be used to return a user-facing error message, as described in [Errors](#errors). |
+
+Responses with any other status code will be interpreted as a failure. The response can include a user-facing message in the `description` field. For details see [Errors](#errors).
+
+#### Body
+
+The response body MUST be a valid JSON Object (`{}`).
+
+For a success response, the expected response body is `{}`.
+
+## Updating a Visibility
+
+### Route
+`PATCH /v1/visibilities/:visibility_id`
+
+`:visibility_id` MUST be the ID of a previously created visibility
+
+#### Headers
+
+The following HTTP Headers are defined for this operation:
+
+| Header | Type | Description |
+| --- | --- | --- |
+| Authorization* | string | Provides a means for authentication and authorization |
+
+\* Headers with an asterisk are REQUIRED.
+
+### Request Body
+```json
+{
+    "platform_id": "038001bc-80bd-4d67-bf3a-956e4d545e3c",
+    "service_plan_id": "fe173a83-df28-4891-8d91-46334e04600d",
+    "labels": [
+        {
+            "op": "add",
+            "key": "label2",
+            "values": ["value2", "value3"]
+        }
+    ]
+}
+```
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| platform_id | string | If present, MUST be the ID of an existing Platform. |
+| service_plan_id | string | If present, MUST be the ID of an existing Service Plan. |
+| labels | array of [Label Changes](#label-changes) | MUST be a valid array of label changes |
+
+\* Fields with an asterisk are REQUIRED.
+
+### Response
+
+| Status Code | Description |
+| ----------- | ----------- |
+| 200 OK | MUST be returned if the visibility was updated as a result of this request. The expected response body is below. |
+| 400 Bad Request | MUST be returned if the request is malformed, missing mandatory data or the visibility update is invalid. An invalid visibility update is one where either the platform_id or service_plan_id do not exist, or a visibility for this service_plan_id already exists, but with an empty platform_id, or the label changes are invalid. The description field MAY be used to return a user-facing error message, providing details about which part of the request is malformed or what data is missing as described in [Errors](#errors).|
+| 404 Not Found | MUST be returned if the requested visibility is missing. The `description` field MAY be used to return a user-facing error message, as described in [Errors](#errors). |
+
+Responses with any other status code will be interpreted as a failure. The response can include a user-facing message in the `description` field. For details see [Errors](#errors).
+
+#### Body
+
+The response body MUST be a valid JSON Object (`{}`).
+
+```json
+{
+    "id": "36931aaf-62a7-4019-a708-0e9abf7e7a8f",
+    "platform_id": "038001bc-80bd-4d67-bf3a-956e4d545e3c",
+    "service_plan_id": "fe173a83-df28-4891-8d91-46334e04600d",
+    "labels": {
+        "label1": ["value1"],
+        "label2": ["value2", "value3"]
+    }
+}
+```
+
+| Response Field | Type | Description |
+| -------------- | ---- | ----------- |
+| id*            | string | ID of the visibility. |
+| platform_id      | string | ID of the Platform for this visibility. |
+| service_plan_id* | string | ID of the Service plan for this visibility. |
+| labels    | [Labels](#labels) object | Labels for this visibility calculated after the update. |
+
+\* Fields with an asterisk are REQUIRED.
+
+## Labels
+
+## Label Changes
 
 ## Information
 

--- a/api.md
+++ b/api.md
@@ -18,7 +18,7 @@
     - [Updating a Service Broker](#updating-a-service-broker)
   - [Visibility Management](#visibility-management)
     - [Creating a Visibility](#creating-a-visibility)
-    - [Retrieving a Visibility](#reitrieving-a-visibility)
+    - [Retrieving a Visibility](#retrieving-a-visibility)
     - [Retrieving All Visibilities](#retrieving-all-visibilities)
     - [Deleting a Visibility](#deleting-a-visibility)
     - [Updating a Visibility](#updating-a-visibility)
@@ -773,7 +773,7 @@ The response body MUST be a valid JSON Object (`{}`).
 | id*            | string | ID of the visibility. |
 | platform_id          | string | ID of the Platform for this visibility. |
 | service_plan_id*    | string | ID of the Service plan for this visibility. |
-| labels    | [Labels](#labels) object | Labels for this visibility. |
+| labels    | [Labels object](#labels-object) | Labels for this visibility. |
 
 \* Fields with an asterisk are REQUIRED.
 
@@ -962,7 +962,7 @@ The following HTTP Headers are defined for this operation:
 | ---- | ---- | ----------- |
 | platform_id | string | If present, MUST be the ID of an existing Platform. |
 | service_plan_id | string | If present, MUST be the ID of an existing Service Plan. |
-| labels | array of [Label Changes](#label-changes) | MUST be a valid array of label changes |
+| labels | array of [Label Change objects](#label-change-object) | MUST be a valid array of label changes |
 
 \* Fields with an asterisk are REQUIRED.
 
@@ -1027,7 +1027,9 @@ This specification does not restrict the allowed character set, length of keys a
 
 ### Attaching Labels
 
-Labels SHOULD be attached to a resource at creation time, or later by updating the respective resource. For example on how to attach a label to a resource post-creation, see [Updating Labels](#updating-labels).
+Labels SHOULD be attached to a resource at [creation time](#when-creating-a-resource), or later by [updating](#when-updating-a-resource) the respective resource.
+
+#### When creating a resource
 
 ### Route
 `POST /v1/:resource_type`
@@ -1079,6 +1081,65 @@ The labels MUST be returned as part of the response.
 
 \* Fields with an asterisk are REQUIRED.
 
+
+#### When updating a resource
+
+### Route
+`PATCH /v1/:resource_type/:resource_id`
+
+`:resource_type` MUST be a valid Service Manager resource type.  
+`:resource_id` MUST be the ID of a previously created resource of this resource type.
+
+### Request Body
+```json
+{
+    ...
+    "labels": [
+        {
+            "op": "add",
+            "key": "label1",
+            "values": ["value1", "value2"]
+        }
+    ]
+}
+```
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| labels* | array of [Label Change objects](#label-change-object) | MUST be a valid array of label changes |
+
+\* Fields with an asterisk are REQUIRED.
+
+### Response
+
+Each `resource type` decides on the returned response statuses.  
+Below are the statuses that are recommended when attaching a label.
+
+| Status Code | Description |
+| ----------- | ----------- |
+| 200 OK | MUST be returned if the labels were attached as a result of this request. The expected response body is below. |
+| 400 Bad Request | MUST be returned if the request is malformed, missing mandatory data or the label detachment is invalid. An invalid label detachment is one where either the label key has invalid syntax, or a label with such key was not previously attached to the resource. The description field MAY be used to return a user-facing error message, providing details about which part of the request is malformed or what data is missing as described in [Errors](#errors).|
+
+
+#### Body
+
+The response body MUST be a valid JSON Object (`{}`).  
+The calculated labels MUST be returned as part of the response.
+
+```json
+{
+    ...
+    "labels": {
+        "label1": ["value1", "value2"]
+    }
+}
+```
+
+| Response Field | Type | Description |
+| -------------- | ---- | ----------- |
+| labels*    | [Labels](#labels) object | Labels for this resource. |
+
+\* Fields with an asterisk are REQUIRED.
+
 ### Detaching Labels
 
 Labels SHOULD be detached only by updating a resource.
@@ -1103,7 +1164,7 @@ Labels SHOULD be detached only by updating a resource.
 ```
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| labels* | array of [Label Changes](#label-change-object) | MUST be a valid array of label changes |
+| labels* | array of [Label Change objects](#label-change-object) | MUST be a valid array of label changes |
 
 \* Fields with an asterisk are REQUIRED.
 
@@ -1134,7 +1195,7 @@ The calculated labels MUST be returned as part of the response.
 
 | Response Field | Type | Description |
 | -------------- | ---- | ----------- |
-| labels*    | [Labels](#labels) object | Labels for this resource. |
+| labels*    | [Labels object](#labels-object) | Labels for this resource. |
 
 \* Fields with an asterisk are REQUIRED.
 
@@ -1163,7 +1224,7 @@ Label values SHOULD be added only by updating the resource that the label is att
 ```
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| labels* | array of [Label Changes](#label-change-object) | MUST be a valid array of label changes |
+| labels* | array of [Label Change objects](#label-change-object) | MUST be a valid array of label changes |
 
 \* Fields with an asterisk are REQUIRED.
 
@@ -1193,7 +1254,7 @@ The calculated labels MUST be returned as part of the response.
 
 | Response Field | Type | Description |
 | -------------- | ---- | ----------- |
-| labels*    | [Labels](#labels) object | Labels for this resource. |
+| labels*    | [Labels object](#labels-object) | Labels for this resource. |
 
 \* Fields with an asterisk are REQUIRED.
 
@@ -1222,7 +1283,7 @@ Label values SHOULD be removed only by updating the resource that the label is a
 ```
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| labels* | array of [Label Changes](#label-change-object) | MUST be a valid array of label changes |
+| labels* | array of [Label Change objects](#label-change-object) | MUST be a valid array of label changes |
 
 \* Fields with an asterisk are REQUIRED.
 
@@ -1252,7 +1313,7 @@ The calculated labels MUST be returned as part of the response.
 
 | Response Field | Type | Description |
 | -------------- | ---- | ----------- |
-| labels*    | [Labels](#labels) object | Labels for this resource. |
+| labels*    | [Labels object](#labels-object) | Labels for this resource. |
 
 \* Fields with an asterisk are REQUIRED.
 


### PR DESCRIPTION
Service Manager should be able to manage platform visibilities. This means that you should be able to say which service (more specifically - plan) is visible in which platform.

In addition, you could have the possibility to further scope the visibility in that platform, if the platform allows it. This can be achieved by attaching labels to a visibility. For example:
Enable service plan `my_plan` in organisations `my_org1` and `my_org2` of cloud foundry platform `cf`, should result in the following visibility:
```json
{
    "platform_id": "cf-id",
    "service_plan_id": "my_plan-id",
    "labels": {
        "org_ids": ["my_org1-id", "my_org2-id"]
    }
}
```