### PR TITLE
Remove "set" label change op from example

### DIFF
--- a/api.md
+++ b/api.md
@@ -1941,8 +1941,7 @@ All operations in one request MUST be performed as one atomic change. Either all
 ...
 "labels": [
     { "op": "add", "key": "label1", "values": ["test1", "test2"] },
-    { "op": "set", "key": "label2", "values": ["test2"] },
-    { "op": "remove", "key": "label3" },
+    { "op": "remove", "key": "label3" }
   ]
 ...  
 ```


### PR DESCRIPTION
"set" operation is not supported and not documented in the supported ops, but it was left in the example.